### PR TITLE
Add support for symbolic link which target qpsh

### DIFF
--- a/bin/qpsh
+++ b/bin/qpsh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export QP_ROOT=$(dirname $0)/..
+export QP_ROOT=$(dirname "$(readlink -f "$0")")/..
 
 bash --init-file <(cat << EOF
     [[ -f /etc/bashrc ]] && source /etc/bashrc 


### PR DESCRIPTION
With this, we can for example add a symbolic link in the bin directory of the user profile and call qpsh from anywhere.