### PR TITLE
Add the posiblity to set custom name when we download git repo

### DIFF
--- a/bin/qp_plugins
+++ b/bin/qp_plugins
@@ -3,7 +3,7 @@
 """
 Usage:
        qp_plugins list [-iuq]
-       qp_plugins download <url>
+       qp_plugins download <url> [-n <name>]
        qp_plugins install <name>...
        qp_plugins uninstall <name>
        qp_plugins create -n <name> [-r <repo>] [<needed_modules>...]
@@ -186,7 +186,10 @@ def main(arguments):
                       url.endswith(".zip"))
         os.chdir(QP_PLUGINS)
         if is_repo:
-            subprocess.check_call(["git", "clone", url])
+            cmd=["git", "clone", url]
+            if arguments["--name"]:
+               cmd=cmd+[arguments["--name"]]
+            subprocess.check_call(cmd)
         else:
             filename = url.split('/')[-1]
 


### PR DESCRIPTION
With this we can run for example
qp plugins download https://github.com/username/repo -n customname (for example username)
and in the plugins folder the repo is named by the custom name