### PR TITLE
Fix for save_for_qmcpack

### DIFF
--- a/src/determinants/determinants.irp.f
+++ b/src/determinants/determinants.irp.f
@@ -479,6 +479,25 @@ subroutine save_wavefunction
     endif
 end
 
+subroutine save_wavefunction_qmcpack
+  implicit none
+  use bitmasks
+  BEGIN_DOC
+  !  Save the wave function into the |EZFIO| file
+  END_DOC
+
+  ! Trick to avoid re-reading the wave function every time N_det changes
+  ! This Trick destroys determinants when saving for qmcpack
+  !read_wf = .False.
+
+  if (N_det < N_states) then
+    return
+  endif
+  if (mpi_master) then
+    call save_wavefunction_general(N_det,N_states,psi_det_sorted,size(psi_coef_sorted,1),psi_coef_sorted)
+    endif
+end
+
 
 subroutine save_wavefunction_unsorted
   implicit none


### PR DESCRIPTION
Fix allowing to call Save_for_qmcpack. 
In subroutine save_wavefunction a call to read_wf=false destroys all determinants when called from save_for_qmcpack. 
To avoid any usefulness the "read_wf=false" another function is created without that call and only called from the QMCPACK plugin. It is minimally invasive. 