### PR TITLE
Changing molden 'Atoms' label to match coordinate units

### DIFF
--- a/src/tools/molden.irp.f
+++ b/src/tools/molden.irp.f
@@ -17,7 +17,7 @@ program molden
 
   write(i_unit_output,'(A)') '[Molden Format]'
 
-  write(i_unit_output,'(A)') '[Atoms] AU'
+  write(i_unit_output,'(A)') '[Atoms] Angs'
   do i = 1, nucl_num
     write(i_unit_output,'(A2,2X,I4,2X,I4,3(2X,F15.10))')                   &
         trim(element_name(int(nucl_charge(i)))),                     &


### PR DESCRIPTION
Fixing a small discrepancy for the Molden writer. The output coordinates were in Angstroms though the [Atoms] section was labeled AU.