### PR TITLE
Fix space in size for EZFIO.cfg

### DIFF
--- a/scripts/ezfio_interface/ei_handler.py
+++ b/scripts/ezfio_interface/ei_handler.py
@@ -398,7 +398,7 @@ def create_ezfio_stuff(dict_ezfio_cfg, config_or_default="config"):
                 try:
                     (begin, end) = map(str.strip, dim.split(":"))
                 except ValueError:
-                    a_size_raw.append(dim)
+                    a_size_raw.append(dim.strip())
                 else:
                     if begin[0] == '-':
                         a_size_raw.append("{0}+{1}+1".format(end, begin[1:]))


### PR DESCRIPTION
People do strange things (By people I mean @anbenali), they put space in EZFIO.cfg size.
```
[qmc_phase]
type: double precision
doc: phase for reconstruction of supercell from k-points
interface: ezfio
size: (2, nuclei.kpt_num, nuclei.kpt_num)
```
Everybody knows that you should not do that..! But anyways, my goal is to make people happy so I fixed the EZFIO.cfg parser to support that.