### PR TITLE
gfortran 10 fixes for QP2 v2.2

### DIFF
--- a/src/csf/connected_to_ref.irp.f
+++ b/src/csf/connected_to_ref.irp.f
@@ -14,7 +14,7 @@ integer*8 function configuration_search_key(cfg,Nint)
   i = shiftr(elec_alpha_num, bit_kind_shift)+1
   configuration_search_key = int(shiftr(ior(cfg(i,1),cfg(i,2)),1)+sum(cfg),8)
 
-  mask = X'00FFFFFFFFFFFFFF'
+  mask = int(Z'00FFFFFFFFFFFFFF',8)
   configuration_search_key = iand(mask,configuration_search_key)
 
   n_open_shells = 1


### PR DESCRIPTION
Since QP 2.2 update, new compilation issues have appeared apparently related to gfortran 10 (which is more syntactically strict).
It seems that I have fixed the issue of BOZ in the `src/csf/connected_to_ref.irp.f` file but other compilation issues appeared when calling the `convertWFfromDETtoCSF` and `convertWFfromCSFtoDET` subroutine in the `src/davidson/diagonalization_hcsf_dressed.irp.f` file. Unfortunately I did not understand where this issue came from.
I was able to see a [reference](https://www.freshports.org/science/cp2k/) to this issue in CP2K
Here the ninja output of this error:
```
/home/mika/qp2/src/basis_correction/IRPF90_temp/davidson/diagonalization_hcsf_dressed.irp.F90:434:45:

  377 |   call convertWFfromDETtoCSF(N_st_diag,U,U_csf) ! davidson/diagonalization_hcsf_dressed.irp.f: 287
      |                                         2    
......
  434 |       call convertWFfromDETtoCSF(N_st_diag,W,W_csf(1,shift+1)) ! davidson/diagonalization_hcsf_dressed.irp.f: 353
      |                                             1
Error: Element of assumed-shape or pointer array as actual argument at (1) cannot correspond to actual argument at (2)
/home/mika/qp2/src/basis_correction/IRPF90_temp/davidson/diagonalization_hcsf_dressed.irp.F90:499:43:

  378 |   call convertWFfromCSFtoDET(N_st_diag,U_csf,U) ! davidson/diagonalization_hcsf_dressed.irp.f: 288
      |                                       2    
......
  499 |       call convertWFfromCSFtoDET(N_st_diag,W_csf(1,shift2+1),W) ! davidson/diagonalization_hcsf_dressed.irp.f: 444
      |                                           1
Error: Element of assumed-shape or pointer array as actual argument at (1) cannot correspond to actual argument at (2)
```
