### PR TITLE
Fix use python3 instead of python2 to run hello.py

### DIFF
--- a/etc/qp.rc
+++ b/etc/qp.rc
@@ -93,7 +93,7 @@ function qp()
 
     "prompt")
       shift
-      python2 $QP_ROOT/scripts/hello.py
+      python3 $QP_ROOT/scripts/hello.py
       function _check_ezfio() {
         if [[ -d ${EZFIO_FILE} ]] ; then
           printf "\e[0;32m|${EZFIO_FILE}>\e[m"


### PR DESCRIPTION
`qpsh` should now use `python3` to run `hellow.py`, not `python2`. This causes an unnecessary dependency on `python2`.