### PR TITLE
Fix for `Floating-point exception` during the calculation of Ncsf

### DIFF
--- a/src/csf/sigma_vector.irp.f
+++ b/src/csf/sigma_vector.irp.f
@@ -56,24 +56,30 @@
       endif
     endif
     ncfg = ncfgpersomo - ncfgprev
-    if(iand(MS,1) .EQ. 0) then
-      !dimcsfpercfg = max(1,nint((binom(i,i/2)-binom(i,i/2+1))))
-      binom1 = dexp(logabsgamma(1.0d0*(i+1))                            &
-                  - logabsgamma(1.0d0*((i/2)+1))                        &
-                  - logabsgamma(1.0d0*(i-((i/2))+1)));
-      binom2 = dexp(logabsgamma(1.0d0*(i+1))                            &
-                  - logabsgamma(1.0d0*(((i/2)+1)+1))                    &
-                  - logabsgamma(1.0d0*(i-((i/2)+1)+1)));
-      dimcsfpercfg = max(1,nint(binom1 - binom2))
+    if(i .EQ. 0 .OR. i .EQ. 1) then
+      dimcsfpercfg = 1
+    elseif( i .EQ. 3) then
+      dimcsfpercfg = 2
     else
-      !dimcsfpercfg = max(1,nint((binom(i,(i+1)/2)-binom(i,(i+3)/2))))
-      binom1 = dexp(logabsgamma(1.0d0*(i+1))                            &
-                  - logabsgamma(1.0d0*(((i+1)/2)+1))                    &
-                  - logabsgamma(1.0d0*(i-(((i+1)/2))+1)));
-      binom2 = dexp(logabsgamma(1.0d0*(i+1))                            &
-                  - logabsgamma(1.0d0*((((i+3)/2)+1)+1))                &
-                  - logabsgamma(1.0d0*(i-(((i+3)/2)+1)+1)));
-      dimcsfpercfg = max(1,nint(binom1 - binom2))
+      if(iand(MS,1) .EQ. 0) then
+        !dimcsfpercfg = max(1,nint((binom(i,i/2)-binom(i,i/2+1))))
+        binom1 = dexp(logabsgamma(1.0d0*(i+1))                            &
+                    - logabsgamma(1.0d0*((i/2)+1))                        &
+                    - logabsgamma(1.0d0*(i-((i/2))+1)));
+        binom2 = dexp(logabsgamma(1.0d0*(i+1))                            &
+                    - logabsgamma(1.0d0*(((i/2)+1)+1))                    &
+                    - logabsgamma(1.0d0*(i-((i/2)+1)+1)));
+        dimcsfpercfg = max(1,nint(binom1 - binom2))
+      else
+        !dimcsfpercfg = max(1,nint((binom(i,(i+1)/2)-binom(i,(i+3)/2))))
+        binom1 = dexp(logabsgamma(1.0d0*(i+1))                            &
+                    - logabsgamma(1.0d0*(((i+1)/2)+1))                    &
+                    - logabsgamma(1.0d0*(i-(((i+1)/2))+1)));
+        binom2 = dexp(logabsgamma(1.0d0*(i+1))                            &
+                    - logabsgamma(1.0d0*((((i+3)/2)+1)+1))                &
+                    - logabsgamma(1.0d0*(i-(((i+3)/2)+1)+1)));
+        dimcsfpercfg = max(1,nint(binom1 - binom2))
+      endif
     endif
     n_CSF += ncfg * dimcsfpercfg
     if(cfg_seniority_index(i+2) > ncfgprev) then


### PR DESCRIPTION
Fixed the bug due to 0 in LogGamma[Ms].