### PR TITLE
avoid uninitialized phase in get_excitation

### DIFF
--- a/src/determinants/slater_rules.irp.f
+++ b/src/determinants/slater_rules.irp.f
@@ -126,6 +126,8 @@ subroutine get_excitation(det1,det2,exc,degree,phase,Nint)
       return
 
     case(0)
+      ! Avoid uninitialized phase
+      phase = 1d0 
       return
 
   end select


### PR DESCRIPTION
Avoid uninitialized phase in get_excitation and get_phase if degree == 0