### PR TITLE
bugfix in restore_symmetry

### DIFF
--- a/src/utils/linear_algebra.irp.f
+++ b/src/utils/linear_algebra.irp.f
@@ -1735,6 +1735,7 @@ subroutine restore_symmetry(m,n,A,LDA,thresh)
 !  enddo
 
   ! Symmetrize
+  i = 1
   do while( (i < sze).and.(-copy(i) > thresh) )
     pi = i
     pf = i


### PR DESCRIPTION
Initiatilzation of "i" has been removed in a previous commit 