### PR TITLE
Fix segfault in scf

### DIFF
--- a/src/scf_utils/roothaan_hall_scf.irp.f
+++ b/src/scf_utils/roothaan_hall_scf.irp.f
@@ -228,9 +228,10 @@ END_DOC
   do while (i<mo_num)
     j=i+1
     m=1
-    do while ( (j<=mo_num).and.(fock_matrix_diag_mo(j)-fock_matrix_diag_mo(i) < 1.d-5) )
+    do while ( (fock_matrix_diag_mo(j)-fock_matrix_diag_mo(i) < 1.d-5) )
       j += 1
       m += 1
+      if (j > mo_num) exit
     enddo
     if (m>1) then
       call dgemm('N','T',ao_num,ao_num,m,1.d0,mo_coef(1,i),size(mo_coef,1),mo_coef(1,i),size(mo_coef,1),0.d0,S,size(S,1))


### PR DESCRIPTION
Evalutating ( (j<=mo_num).and.(fock_matrix_diag_mo(j)-fock_matrix_diag_mo(i) < 1.d-5) ) cause a segfault with gfortran compiler as soon as j > mo_num, the two conditions must be evaluated separately.